### PR TITLE
PCT-1211 Message when installing agent on MySQL 5.0

### DIFF
--- a/Godeps.json
+++ b/Godeps.json
@@ -39,7 +39,7 @@
 			"Rev": "65f3771e91669a6e4251fafcc6d93ffe5e2ff03f"
 		},
         {
-            "ImportPath": "github.com/hashicorp/go-version",
+            "Pkg": "github.com/hashicorp/go-version",
             "Rev": "bb92dddfa9792e738a631f04ada52858a139bcf7"
         }
 	]

--- a/Godeps.json
+++ b/Godeps.json
@@ -37,6 +37,10 @@
 		{
 			"Pkg": "github.com/go-test/test",
 			"Rev": "65f3771e91669a6e4251fafcc6d93ffe5e2ff03f"
-		}
+		},
+        {
+            "ImportPath": "github.com/hashicorp/go-version",
+            "Rev": "bb92dddfa9792e738a631f04ada52858a139bcf7"
+        }
 	]
 }

--- a/bin/percona-agent-installer/installer/mysql.go
+++ b/bin/percona-agent-installer/installer/mysql.go
@@ -133,7 +133,6 @@ func (i *Installer) createNewMySQLUser() (dsn mysql.DSN, err error) {
 	if err != nil {
 		return dsn, err
 	}
-	tmpConn.Close()
 
 	if !isVersionSupported {
 		return dsn, fmt.Errorf("MySQL version not supported. It should be > %s", agent.MIN_SUPPORTED_MYSQL_VERSION)
@@ -193,7 +192,6 @@ func (i *Installer) useExistingMySQLUser() (mysql.DSN, error) {
 	if err != nil {
 		return userDSN, err
 	}
-	tmpConn.Close()
 	if !isVersionSupported {
 		return userDSN, fmt.Errorf("MySQL version not supported. It should be > %s", agent.MIN_SUPPORTED_MYSQL_VERSION)
 	}
@@ -363,6 +361,7 @@ func (i *Installer) IsVersionSupported(conn mysql.Connector) (bool, error) {
 	if err := conn.Connect(1); err != nil {
 		return false, err
 	}
+	defer conn.Close()
 	mysqlVersion := conn.GetGlobalVarString("version") // Version in the form m.n.o-ubuntu
 	re := regexp.MustCompile("-.*$")
 	mysqlVersion = re.ReplaceAllString(mysqlVersion, "") // Strip everything after the first dash


### PR DESCRIPTION
- Fixed for cases like MariaDB v10
- Using hashicorp/go-version package.
- Added tests for malformed versions and for cases where the string comparison would fail (e.g. string "10.0" < "5.1" but numeric 10.0 > 5.1)