### PR TITLE
PCT-805: check if pid in pidfile corresponds to percona-agent

### DIFF
--- a/install/mock/percona-agent.go
+++ b/install/mock/percona-agent.go
@@ -1,0 +1,113 @@
+/*
+   Copyright (c) 2014-2015, Percona LLC and/or its affiliates. All rights reserved.
+
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU Affero General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU Affero General Public License for more details.
+
+   You should have received a copy of the GNU Affero General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>
+*/
+
+// Mocking percona-agent only for init script testing purposes.
+// init script relies on /proc fs to determine if the binary running
+// under pidfile corresponds to a percona-agent.
+// This partial mock service takes two cmd line args, mandatory basedir and
+// optional pidfile. The program will just create the PID file and loop forever.
+//
+// Fail Exit status codes:
+// 2 - User did not provide basedir flag
+// 3 - Could not create pidfile
+// 4 - Could not write to pidfile
+// 5 - Could not close pidfile
+
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"strconv"
+	"syscall"
+	"time"
+)
+
+var (
+	flagBasedir string
+	flagPidFile string
+)
+
+func init() {
+	flag.StringVar(&flagBasedir, "basedir", "", "Agent basedir")
+	flag.StringVar(&flagPidFile, "pidfile", "percona-agent.pid", "PID file")
+	flag.Parse()
+}
+
+func main() {
+
+	if err := flag.CommandLine.Parse(os.Args[1:]); err != nil {
+		os.Exit(10)
+	}
+
+	if flagBasedir == "" {
+		os.Exit(2)
+	}
+
+	sdelay := os.Getenv("TEST_PERCONA_AGENT_START_DELAY")
+	delay, err := strconv.ParseFloat(sdelay, 32)
+	if err != nil {
+		delay = 0
+	}
+
+	time.Sleep(time.Second * time.Duration(delay))
+
+	if !filepath.IsAbs(flagPidFile) {
+		flagPidFile = filepath.Join(flagBasedir, flagPidFile)
+	}
+
+	// Create new PID file, success only if it doesn't already exist.
+	flags := os.O_CREATE | os.O_EXCL | os.O_WRONLY
+	file, err := os.OpenFile(flagPidFile, flags, 0644)
+
+	if err != nil {
+		os.Exit(3)
+	}
+
+	// Write PID to new PID file and close.
+	if _, err := file.WriteString(fmt.Sprintf("%d\n", os.Getpid())); err != nil {
+		os.Exit(4)
+	}
+	if err := file.Close(); err != nil {
+		os.Exit(5)
+	}
+
+	sigc := make(chan os.Signal, 1)
+	signal.Notify(sigc,
+		syscall.SIGINT,
+		syscall.SIGTERM,
+		syscall.SIGQUIT)
+
+	go func() {
+		_ = <-sigc
+		sdelay := os.Getenv("TEST_PERCONA_AGENT_STOP_DELAY")
+		delay, err := strconv.ParseFloat(sdelay, 32)
+		if err != nil {
+			delay = 0
+		}
+		time.Sleep(time.Second * time.Duration(delay))
+		os.Remove(flagPidFile)
+		os.Exit(0)
+	}()
+
+	for {
+		time.Sleep(time.Millisecond * 500)
+	}
+}

--- a/install/mock/percona-agent.go
+++ b/install/mock/percona-agent.go
@@ -61,7 +61,7 @@ func main() {
 		os.Exit(2)
 	}
 
-	startDelayEnv := os.Getenv("TEST_PERCONA_AGENT_START_DELAY")
+	startDelayEnv := os.Getenv("PCT_TEST_START_DELAY")
 	startDelay, err := strconv.ParseFloat(startDelayEnv, 32)
 	if err != nil {
 		startDelay = 0
@@ -96,7 +96,7 @@ func main() {
 		syscall.SIGQUIT)
 
 	_ = <-sigc
-	stopDelayEnv := os.Getenv("TEST_PERCONA_AGENT_STOP_DELAY")
+	stopDelayEnv := os.Getenv("PCT_TEST_STOP_DELAY")
 	stopDelay, err := strconv.ParseFloat(stopDelayEnv, 32)
 	if err != nil {
 		stopDelay = 0

--- a/install/mock/percona-agent.go
+++ b/install/mock/percona-agent.go
@@ -1,5 +1,5 @@
 /*
-   Copyright (c) 2014-2015, Percona LLC and/or its affiliates. All rights reserved.
+   Copyright (c) 2015, Percona LLC and/or its affiliates. All rights reserved.
 
    This program is free software: you can redistribute it and/or modify
    it under the terms of the GNU Affero General Public License as published by

--- a/install/percona-agent
+++ b/install/percona-agent
@@ -49,7 +49,7 @@ LOGFILE="$BASEDIR/$SERVICE.log"
 
 # Agent does not manager its own PID file; system is expected to manager this.
 PIDFILE="$BASEDIR/$SERVICE.pid"
-pid=""
+PID=""
 
 # Allow configuration overrides in /etc/sysconfig/$SERVICE
 CONFIGFILE="/etc/sysconfig/$SERVICE"
@@ -113,42 +113,57 @@ _seq() {
    awk "BEGIN { for(i=1; i<=$i; i++) print i; }"
 }
 
-testpid() {
-	# This function will check if the process under $pid runs $SERVICE
-    # if not, it will delete $PIDFILE and set $pid to empty string
-    psoutput=`ps -p "$pid" -o pid,comm | grep -w "$pid"` 
-    pid=`echo "$psoutput" | awk '{print $1}'`
-    # Make sure $SERVICE shows up in command name
-    match=`echo "$psoutput" | awk '{print $2}' | grep "$SERVICE"`
+is_pid_running_agent() {
+	# This will check if the process under $PID runs $SERVICE
+    if [ -z "$PID" ]; then
+        # ps does not like empty string as pid
+        return 1
+    fi
+    match=`ps -p "$PID" -o comm | grep -o "$SERVICE"`
     if [ -z "$match" ]; then
-       pid=""
-       # This is a stale pid file.
-       rm -f "$PIDFILE"
-       # Check if message to display was provided
-       if [ ! -z "$1" ]; then
-          echo "$1"
-       fi
+       return 1
+    fi
+    return 0
+}
+
+remove_stale_pidfile() {
+    # Remove the pidfile checking the success of operation
+    # if succeeds echo optional $1 parameter
+    # Note: rm will always exit with status 0
+    found="no"
+    if [ -f "$PIDFILE" ]; then
+        found="yes"
+    fi
+    rm -f "$PIDFILE"
+    if [ $found = "yes" ] && [ ! -f "$PIDFILE" ] && [ -n "$1" ]; then
+        # If file was actually deleted and a message to display was provided
+        echo "$1"
     fi
 }
 
-getpid() {
-   if [ -f $PIDFILE ]; then
-      if [ ! -r $PIDFILE ]; then
-         echo "Cannot read $PIDFILE." >&2
-         exit 1
-      fi
-      pid=`cat $PIDFILE`
-	  # Verify that a process with this pid is still running percona-agent
-      testpid "Removed stale pid file: $PIDFILE"
+get_pid_from_file() {
+   PID=""
+   if [ ! -f $PIDFILE ]; then
+      return 1
    fi
+
+   if [ ! -r $PIDFILE ]; then
+      echo "Cannot read $PIDFILE." >&2
+      exit 1
+   fi
+
+   PID=`cat $PIDFILE`
+   return 0
 }
 
 start() {
    chown "$USERNAME" "$BASEDIR" || exit 1
 
    echo "Starting $SERVICE..."
-   getpid
-   if [ "$pid" ]; then
+   get_pid_from_file
+   if ! is_pid_running_agent; then
+        remove_stale_pidfile "Removed stale pid file: $PIDFILE"
+   else
       echo "$SERVICE is already running."
       exit 0
    fi
@@ -160,8 +175,7 @@ start() {
    # so let's give an agent some time to start
    echo "Waiting for $SERVICE to start..."
    for x in $(_seq $START_TIMEOUT); do
-       getpid
-       if [ -n "$pid" ]; then
+       if get_pid_from_file && is_pid_running_agent; then
            break
        fi
        sleep 1
@@ -169,7 +183,7 @@ start() {
 
    # Process is started in background so $? does not have its exit status.
    # Instead, check that it's running by trying to get its PID.
-   if [ -z "$pid" ]; then
+   if ! is_pid_running_agent; then
       echo "Fail.  Check $LOGFILE for details."
       exit 1
    else
@@ -179,43 +193,43 @@ start() {
 
 stop() {
     echo "Stopping $SERVICE..."
-    getpid
-    if [ "X$pid" = "X" ]; then
+    get_pid_from_file
+    if ! is_pid_running_agent; then
+        remove_stale_pidfile "Removed stale pid file: $PIDFILE"
+    fi
+    if ! is_pid_running_agent; then
         echo "$SERVICE is not running."
         return 0
     else
-         # Running so try to stop it.
-        kill $pid >/dev/null 2>&1
+        # Running so try to stop it.
+        kill "$PID" >/dev/null 2>&1
         if [ $? -ne 0 ]; then
-            # An explanation for the failure should have been given
             echo "Unable to stop $SERVICE."
             return 1
         fi
  
         #  Loop until it does.
         echo "Waiting for $SERVICE to exit..."
-        savepid=$pid
+        savepid=$PID
         for x in $(_seq $STOP_TIMEOUT); do
-            testpid
-            if [ -z "$pid" ]; then
-                break
+            if ! is_pid_running_agent; then
+                break;    
             fi
             sleep 1
         done
  
-        pid=$savepid
-        testpid
-        if [ "X$pid" != "X" ]; then
-            echo "Time out waiting for $SERVICE to exit.  Trying kill -9 $pid..."
-            kill -9 $pid
+        PID=$savepid
+        if is_pid_running_agent; then
+            echo "Time out waiting for $SERVICE to exit.  Trying kill -9 $PID..."
+            kill -9 $PID
         fi
  
-        pid=$savepid
-        testpid
-        if [ "X$pid" != "X" ]; then
+        PID=$savepid
+        if is_pid_running_agent; then
             echo "Failed to stop $SERVICE."
             return 1
         else
+            remove_stale_pidfile 
             echo "Stopped $SERVICE."
             return 0
         fi
@@ -223,9 +237,8 @@ stop() {
 }
  
 status() {
-   getpid
-   if [ "$pid" ]; then
-      echo "$SERVICE is running ($pid)."
+   if get_pid_from_file && is_pid_running_agent; then
+      echo "$SERVICE is running ($PID)."
       exit 0
    else
       echo "$SERVICE is not running."

--- a/install/percona-agent
+++ b/install/percona-agent
@@ -131,11 +131,11 @@ remove_stale_pidfile() {
     # if succeeds echo optional $1 parameter
     # Note: rm will always exit with status 0
     found="no"
-    if [ -f "$PIDFILE" ]; then
+    if [ -f $PIDFILE ]; then
         found="yes"
     fi
     rm -f "$PIDFILE"
-    if [ $found = "yes" ] && [ ! -f "$PIDFILE" ] && [ -n "$1" ]; then
+    if [ $found = "yes" ] && [ ! -f $PIDFILE ] && [ -n "$1" ]; then
         # If file was actually deleted and a message to display was provided
         echo "$1"
     fi

--- a/install/percona-agent
+++ b/install/percona-agent
@@ -23,7 +23,7 @@ SERVICE="percona-agent"
 # Agent needs to run as root to read MySQL slow log for Query Analytics (QAN).
 # If not running QAN, a normal user will work.
 # Environment variable config takes priority
-if [ -n "$PERCONA_AGENT_USER" ]; then
+if [ ! "x$PERCONA_AGENT_USER" = "x" ]; then
     USERNAME="$PERCONA_AGENT_USER"
 else
     USERNAME='root'
@@ -31,7 +31,7 @@ fi
 
 # Agent uses a single base directory for all its files and data.
 # Environment variable config takes priority
-if [ -n "$PERCONA_AGENT_DIR" ] && [ -d "$PERCONA_AGENT_DIR" ] ; then
+if [ ! "x$PERCONA_AGENT_DIR" = "x" ] && [ -d "$PERCONA_AGENT_DIR" ] ; then
     # Remove trailing slash
     BASEDIR=$( cd "$PERCONA_AGENT_DIR" && pwd )
 else
@@ -48,6 +48,32 @@ if [ ! -x "$CMD" ]; then
    echo "$CMD does not exist or is not executable. Check that $SERVICE" \
         "has been installed correctly." >&2
    exit 1
+fi
+
+DEFAULT_START_TIMEOUT="5"
+# Set default if env not set
+if [ "x$PERCONA_AGENT_START_TIMEOUT" = "x" ]; then
+    PERCONA_AGENT_START_TIMEOUT=$DEFAULT_START_TIMEOUT
+fi
+
+# validate
+echo "$PERCONA_AGENT_START_TIMEOUT" | grep -q '^[0-9]+$' &> /dev/null
+if [ $? -ne 0 ]; then
+     # Using default start timeout
+     PERCONA_AGENT_START_TIMEOUT=$DEFAULT_START_TIMEOUT
+fi
+
+DEFAULT_STOP_TIMEOUT="60"
+# Set default if env not set
+if [ "x$PERCONA_AGENT_STOP_TIMEOUT" = "x" ]; then
+    PERCONA_AGENT_STOP_TIMEOUT=$DEFAULT_STOP_TIMEOUT
+fi
+
+# validate
+echo "$PERCONA_AGENT_STOP_TIMEOUT" | grep -q '^[0-9]+$' &> /dev/null
+if [ $? -ne 0 ]; then
+     # Using default start timeout
+     PERCONA_AGENT_STOP_TIMEOUT=$DEFAULT_STOP_TIMEOUT
 fi
 
 # Agent may use a different log file, or no log file (online logging only),
@@ -132,7 +158,7 @@ getpid() {
          exit 1
       fi
       pid=`cat $PIDFILE`
-      # Verify that a process with this pid is still running percona-agent
+	  # Verify that a process with this pid is still running percona-agent
       binforpid=`$READLINK -m "/proc/$pid/exe" | awk '{print $1}'`
       if [ ! "$binforpid" = "$CMD" ]
       then
@@ -170,7 +196,7 @@ start() {
    # as we are starting agent in background,
    # so let's give an agent some time to start
    echo "Waiting for $SERVICE to start..."
-   for x in $(_seq 5); do
+   for x in $(_seq $PERCONA_AGENT_START_TIMEOUT); do
        getpid
        if [ -n "$pid" ]; then
            break
@@ -197,7 +223,7 @@ stop() {
         return 0
     else
          # Running so try to stop it.
-        su --command="kill $pid" $USERNAME
+        kill $pid &> /dev/null
         if [ $? -ne 0 ]
         then
             # An explanation for the failure should have been given
@@ -208,7 +234,7 @@ stop() {
         #  Loop until it does.
         echo "Waiting for $SERVICE to exit..."
         savepid=$pid
-        for x in $(_seq 60); do
+        for x in $(_seq $PERCONA_AGENT_STOP_TIMEOUT); do
             testpid
             if [ -z "$pid" ]; then
                 break

--- a/install/percona-agent
+++ b/install/percona-agent
@@ -22,10 +22,22 @@ SERVICE="percona-agent"
 
 # Agent needs to run as root to read MySQL slow log for Query Analytics (QAN).
 # If not running QAN, a normal user will work.
-USERNAME="root"
+# Environment variable config takes priority
+if [ -n "$PERCONA_AGENT_USER" ]; then
+    USERNAME="$PERCONA_AGENT_USER"
+else
+    USERNAME='root'
+fi
 
 # Agent uses a single base directory for all its files and data.
-BASEDIR="/usr/local/percona/$SERVICE"
+# Environment variable config takes priority
+if [ -n "$PERCONA_AGENT_DIR" ] && [ -d "$PERCONA_AGENT_DIR" ] ; then
+    # Remove trailing slash
+    BASEDIR=$( cd "$PERCONA_AGENT_DIR" && pwd )
+else
+    BASEDIR="/usr/local/percona/$SERVICE"
+fi
+
 if [ ! -d "$BASEDIR" ]; then
    mkdir -p "$BASEDIR" || exit 1
 fi

--- a/install/percona-agent
+++ b/install/percona-agent
@@ -157,13 +157,19 @@ getpid() {
       fi
       pid=`cat $PIDFILE`
 	  # Verify that a process with this pid is still running percona-agent
-      if [ $USE_PROCFS == "yes" ]; then
+      if [ $USE_PROCFS = "yes" ]; then
           binforpid=`readlink -m "$PROCFSPATH/$pid/exe" | awk '{print $1}'`
           if [ ! "$binforpid" = "$CMD" ]; then
               pid=""
           fi
       else
-          pid=`ps -p $pid | grep $pid | grep -v grep | tail -1 | awk '{print $1}'`
+          psoutput=`ps -p $pid -o pid,comm | grep $pid | grep -v grep | tail -1` 
+          pid=`echo "$psoutput" | awk '{print $1}'`
+          # Make sure $SERVICE shows up in command name
+          match=`echo "$psoutput" | awk '{print $2}' | grep "$SERVICE"`
+          if [ -z "$match" ]; then
+              pid=""
+          fi
       fi
 
       if [ -z "$pid" ]; then
@@ -175,14 +181,20 @@ getpid() {
 }
 
 testpid() {
-    if [ $USE_PROCFS == "yes" ]; then
+    if [ $USE_PROCFS = "yes" ]; then
         binforpid=`readlink -m "/proc/$pid/exe" | awk '{print $1}'`
         if [ ! "$binforpid" = "$CMD" ]; then
-            # Process is gone so remove the pid file.
+            # Process is gone reset pid var
             pid=""
         fi
     else
-        pid=`ps -p $pid | grep $pid | grep -v grep | tail -1 | awk '{print $1}'`
+        psoutput=`ps -p $pid -o pid,comm | grep $pid | grep -v grep | tail -1` 
+        pid=`echo "$psoutput" | awk '{print $1}'`
+        # Make sure $SERVICE shows up in command name
+        match=`echo "$psoutput" | awk '{print $2}' | grep "$SERVICE"`
+        if [ -z "$match" ]; then
+           pid="" 
+        fi
     fi
 
     if [ -z "$pid" ]; then

--- a/install/percona-agent
+++ b/install/percona-agent
@@ -113,6 +113,24 @@ _seq() {
    awk "BEGIN { for(i=1; i<=$i; i++) print i; }"
 }
 
+testpid() {
+	# This function will check if the process under $pid runs $SERVICE
+    # if not, it will delete $PIDFILE and set $pid to empty string
+    psoutput=`ps -p "$pid" -o pid,comm | grep -w "$pid"` 
+    pid=`echo "$psoutput" | awk '{print $1}'`
+    # Make sure $SERVICE shows up in command name
+    match=`echo "$psoutput" | awk '{print $2}' | grep "$SERVICE"`
+    if [ -z "$match" ]; then
+       pid=""
+       # This is a stale pid file.
+       rm -f "$PIDFILE"
+       # Check if message to display was provided
+       if [ ! -z "$1" ]; then
+          echo "$1"
+       fi
+    fi
+}
+
 getpid() {
    if [ -f $PIDFILE ]; then
       if [ ! -r $PIDFILE ]; then
@@ -121,30 +139,8 @@ getpid() {
       fi
       pid=`cat $PIDFILE`
 	  # Verify that a process with this pid is still running percona-agent
-      psoutput=`ps -p "$pid" -o pid,comm | grep "$pid" | tail -1` 
-      pid=`echo "$psoutput" | awk '{print $1}'`
-      # Make sure $SERVICE shows up in command name
-      match=`echo "$psoutput" | awk '{print $2}' | grep "$SERVICE"`
-      if [ -z "$match" ]; then
-         pid=""
-         # This is a stale pid file.
-         rm -f "$PIDFILE"
-         echo "Removed stale pid file: $PIDFILE"
-      fi
+      testpid "Removed stale pid file: $PIDFILE"
    fi
-}
-
-testpid() {
-	# Verify that a process with this pid is still running percona-agent
-    psoutput=`ps -p "$pid" -o pid,comm | grep "$pid" | tail -1` 
-    pid=`echo "$psoutput" | awk '{print $1}'`
-    # Make sure $SERVICE shows up in command name
-    match=`echo "$psoutput" | awk '{print $2}' | grep "$SERVICE"`
-    if [ -z "$match" ]; then
-       pid=""
-       # This is a stale pid file.
-       rm -f "$PIDFILE"
-    fi
 }
 
 start() {

--- a/install/percona-agent
+++ b/install/percona-agent
@@ -22,17 +22,10 @@ SERVICE="percona-agent"
 
 # Agent needs to run as root to read MySQL slow log for Query Analytics (QAN).
 # If not running QAN, a normal user will work.
-# Environment variable config takes priority
-USERNAME="${PERCONA_AGENT_USER:-root}"
+USERNAME="${PCT_TEST_AGENT_USER:-root}"
 
 # Agent uses a single base directory for all its files and data.
-# Environment variable config takes priority
-if [ ! "x$PERCONA_AGENT_DIR" = "x" ] && [ -d "$PERCONA_AGENT_DIR" ] ; then
-    # Normalize path, removing trailing slashes, relative paths, etc
-    BASEDIR=$( cd "$PERCONA_AGENT_DIR" && pwd )
-else
-    BASEDIR="/usr/local/percona/$SERVICE"
-fi
+BASEDIR="${PCT_TEST_AGENT_DIR:-"/usr/local/percona/$SERVICE"}"
 
 if [ ! -d "$BASEDIR" ]; then
    mkdir -p "$BASEDIR" || exit 1
@@ -46,23 +39,9 @@ if [ ! -x "$CMD" ]; then
    exit 1
 fi
 
-DEFAULT_START_TIMEOUT="5"
-PERCONA_AGENT_START_TIMEOUT="${PERCONA_AGENT_START_TIMEOUT:-$DEFAULT_START_TIMEOUT}"
-# Validate
-echo "$PERCONA_AGENT_START_TIMEOUT" | grep -q '^[0-9]+$' >/dev/null 2>&1
-if [ $? -eq 0 ]; then
-     # Using default start timeout
-     PERCONA_AGENT_START_TIMEOUT=$DEFAULT_START_TIMEOUT
-fi
-
-DEFAULT_STOP_TIMEOUT="60"
-PERCONA_AGENT_STOP_TIMEOUT="${PERCONA_AGENT_STOP_TIMEOUT:-$DEFAULT_STOP_TIMEOUT}"
-# Validate
-echo "$PERCONA_AGENT_STOP_TIMEOUT" | grep -q '^[0-9]+$' >/dev/null 2>&1
-if [ $? -eq 0 ]; then
-     # Using default stop timeout
-     PERCONA_AGENT_STOP_TIMEOUT=$DEFAULT_STOP_TIMEOUT
-fi
+# Start and stop timeouts for the service
+START_TIMEOUT="${PCT_TEST_START_TIMEOUT:-5}"
+STOP_TIMEOUT="${PCT_TEST_STOP_TIMEOUT:-60}"
 
 # Agent may use a different log file, or no log file (online logging only),
 # but we should capture any output, e.g. in case it crashes.
@@ -184,7 +163,7 @@ start() {
    # as we are starting agent in background,
    # so let's give an agent some time to start
    echo "Waiting for $SERVICE to start..."
-   for x in $(_seq $PERCONA_AGENT_START_TIMEOUT); do
+   for x in $(_seq $START_TIMEOUT); do
        getpid
        if [ -n "$pid" ]; then
            break
@@ -220,7 +199,7 @@ stop() {
         #  Loop until it does.
         echo "Waiting for $SERVICE to exit..."
         savepid=$pid
-        for x in $(_seq $PERCONA_AGENT_STOP_TIMEOUT); do
+        for x in $(_seq $STOP_TIMEOUT); do
             testpid
             if [ -z "$pid" ]; then
                 break

--- a/install/percona-agent
+++ b/install/percona-agent
@@ -196,8 +196,6 @@ stop() {
     get_pid_from_file
     if ! is_pid_running_agent; then
         remove_stale_pidfile "Removed stale pid file: $PIDFILE"
-    fi
-    if ! is_pid_running_agent; then
         echo "$SERVICE is not running."
         return 0
     else

--- a/install/percona-agent
+++ b/install/percona-agent
@@ -23,16 +23,12 @@ SERVICE="percona-agent"
 # Agent needs to run as root to read MySQL slow log for Query Analytics (QAN).
 # If not running QAN, a normal user will work.
 # Environment variable config takes priority
-if [ ! "x$PERCONA_AGENT_USER" = "x" ]; then
-    USERNAME="$PERCONA_AGENT_USER"
-else
-    USERNAME='root'
-fi
+USERNAME="${PERCONA_AGENT_USER:-root}"
 
 # Agent uses a single base directory for all its files and data.
 # Environment variable config takes priority
 if [ ! "x$PERCONA_AGENT_DIR" = "x" ] && [ -d "$PERCONA_AGENT_DIR" ] ; then
-    # Remove trailing slash
+    # Normalize path, removing trailing slashes, relative paths, etc
     BASEDIR=$( cd "$PERCONA_AGENT_DIR" && pwd )
 else
     BASEDIR="/usr/local/percona/$SERVICE"
@@ -51,28 +47,20 @@ if [ ! -x "$CMD" ]; then
 fi
 
 DEFAULT_START_TIMEOUT="5"
-# Set default if env not set
-if [ "x$PERCONA_AGENT_START_TIMEOUT" = "x" ]; then
-    PERCONA_AGENT_START_TIMEOUT=$DEFAULT_START_TIMEOUT
-fi
-
-# validate
-echo "$PERCONA_AGENT_START_TIMEOUT" | grep -q '^[0-9]+$' &> /dev/null
-if [ $? -ne 0 ]; then
+PERCONA_AGENT_START_TIMEOUT="${PERCONA_AGENT_START_TIMEOUT:-$DEFAULT_START_TIMEOUT}"
+# Validate
+echo "$PERCONA_AGENT_START_TIMEOUT" | grep -q '^[0-9]+$' >/dev/null 2>&1
+if [ $? -eq 0 ]; then
      # Using default start timeout
      PERCONA_AGENT_START_TIMEOUT=$DEFAULT_START_TIMEOUT
 fi
 
 DEFAULT_STOP_TIMEOUT="60"
-# Set default if env not set
-if [ "x$PERCONA_AGENT_STOP_TIMEOUT" = "x" ]; then
-    PERCONA_AGENT_STOP_TIMEOUT=$DEFAULT_STOP_TIMEOUT
-fi
-
-# validate
-echo "$PERCONA_AGENT_STOP_TIMEOUT" | grep -q '^[0-9]+$' &> /dev/null
-if [ $? -ne 0 ]; then
-     # Using default start timeout
+PERCONA_AGENT_STOP_TIMEOUT="${PERCONA_AGENT_STOP_TIMEOUT:-$DEFAULT_STOP_TIMEOUT}"
+# Validate
+echo "$PERCONA_AGENT_STOP_TIMEOUT" | grep -q '^[0-9]+$' >/dev/null 2>&1
+if [ $? -eq 0 ]; then
+     # Using default stop timeout
      PERCONA_AGENT_STOP_TIMEOUT=$DEFAULT_STOP_TIMEOUT
 fi
 
@@ -124,17 +112,27 @@ REALPATH=`echo $REALPATH | sed -e 's;:; ;g'`
 # Change the current directory to the location of the script
 cd "`dirname "$REALPATH"`"
 
-# Resolve the location of the 'readlink' command
-READLINK="/usr/bin/readlink"
-if [ ! -x $READLINK ]
-then
-    READLINK="/bin/readlink"
-    if [ ! -x $READLINK ]
-    then
-        echo "Unable to locate 'readlink'." >&2
-        echo "Please report this with the location on your system." >&2
-        exit 1
-    fi
+# Use procfs by default
+USE_PROCFS="yes"
+
+# Detect if we have procfs
+PROCFSPATH=`mount -l -t proc | tail | awk '{print $3}'`
+if [ -z "$PROCFSPATH" ]; then
+     USE_PROCFS="no" 
+fi
+
+# Check for readlink in path, disable procfs if not found
+readlink --version >/dev/null 2>&1
+if [ $? -ne 0 ]; then
+     USE_PROCFS="no" 
+fi
+
+# Check for ps in path
+ps --version >/dev/null 2>&1
+if [ $? -ne 0 ]; then
+     echo "Unable to locate 'ps'." >&2
+     echo "Please report this with the location on your system." >&2
+     exit 1
 fi
 
 # Build the nice clause
@@ -159,11 +157,17 @@ getpid() {
       fi
       pid=`cat $PIDFILE`
 	  # Verify that a process with this pid is still running percona-agent
-      binforpid=`$READLINK -m "/proc/$pid/exe" | awk '{print $1}'`
-      if [ ! "$binforpid" = "$CMD" ]
-      then
+      if [ $USE_PROCFS == "yes" ]; then
+          binforpid=`readlink -m "$PROCFSPATH/$pid/exe" | awk '{print $1}'`
+          if [ ! "$binforpid" = "$CMD" ]; then
+              pid=""
+          fi
+      else
+          pid=`ps -p $pid | grep $pid | grep -v grep | tail -1 | awk '{print $1}'`
+      fi
+
+      if [ -z "$pid" ]; then
          # This is a stale pid file.
-         pid=""
          rm -f $PIDFILE
          echo "Removed stale pid file: $PIDFILE"
       fi
@@ -171,12 +175,19 @@ getpid() {
 }
 
 testpid() {
-    binforpid=`$READLINK -m "/proc/$pid/exe" | awk '{print $1}'`
-    if [ ! "$binforpid" = "$CMD" ]
-    then
-        # Process is gone so remove the pid file.
-        pid=""
-        rm -f $PIDFILE
+    if [ $USE_PROCFS == "yes" ]; then
+        binforpid=`readlink -m "/proc/$pid/exe" | awk '{print $1}'`
+        if [ ! "$binforpid" = "$CMD" ]; then
+            # Process is gone so remove the pid file.
+            pid=""
+        fi
+    else
+        pid=`ps -p $pid | grep $pid | grep -v grep | tail -1 | awk '{print $1}'`
+    fi
+
+    if [ -z "$pid" ]; then
+         # This is a stale pid file.
+         rm -f $PIDFILE
     fi
 }
 
@@ -217,15 +228,13 @@ start() {
 stop() {
     echo "Stopping $SERVICE..."
     getpid
-    if [ "X$pid" = "X" ]
-    then
+    if [ "X$pid" = "X" ]; then
         echo "$SERVICE is not running."
         return 0
     else
          # Running so try to stop it.
-        kill $pid &> /dev/null
-        if [ $? -ne 0 ]
-        then
+        kill $pid >/dev/null 2>&1
+        if [ $? -ne 0 ]; then
             # An explanation for the failure should have been given
             echo "Unable to stop $SERVICE."
             return 1
@@ -244,16 +253,14 @@ stop() {
  
         pid=$savepid
         testpid
-        if [ "X$pid" != "X" ]
-        then
+        if [ "X$pid" != "X" ]; then
             echo "Time out waiting for $SERVICE to exit.  Trying kill -9 $pid..."
             kill -9 $pid
         fi
  
         pid=$savepid
         testpid
-        if [ "X$pid" != "X" ]
-        then
+        if [ "X$pid" != "X" ]; then
             echo "Failed to stop $SERVICE."
             return 1
         else

--- a/install/percona-agent
+++ b/install/percona-agent
@@ -85,20 +85,20 @@ REALPATH=`echo $REALPATH | sed -e 's;:; ;g'`
  
 # Change the current directory to the location of the script
 cd "`dirname "$REALPATH"`"
-  
-# Resolve the location of the 'ps' command
-PSEXE="/usr/bin/ps"
-if [ ! -x $PSEXE ]
+
+# Resolve the location of the 'readlink' command
+READLINK="/usr/bin/readlink"
+if [ ! -x $READLINK ]
 then
-    PSEXE="/bin/ps"
-    if [ ! -x $PSEXE ]
+    READLINK="/bin/readlink"
+    if [ ! -x $READLINK ]
     then
-        echo "Unable to locate 'ps'." >&2
+        echo "Unable to locate 'readlink'." >&2
         echo "Please report this with the location on your system." >&2
         exit 1
     fi
 fi
- 
+
 # Build the nice clause
 if [ "X$PRIORITY" = "X" ]
 then
@@ -120,10 +120,12 @@ getpid() {
          exit 1
       fi
       pid=`cat $PIDFILE`
-      # Verify that a process with this pid is still running.
-      pid=`$PSEXE -p $pid | grep $pid | grep -v grep | tail -1 | awk '{print $1}'`
-      if [ -z "$pid" ]; then
+      # Verify that a process with this pid is still running percona-agent
+      binforpid=`$READLINK -m "/proc/$pid/exe" | awk '{print $1}'`
+      if [ ! "$binforpid" = "$CMD" ]
+      then
          # This is a stale pid file.
+         pid=""
          rm -f $PIDFILE
          echo "Removed stale pid file: $PIDFILE"
       fi
@@ -131,10 +133,11 @@ getpid() {
 }
 
 testpid() {
-    pid=`$PSEXE -p $pid | grep $pid | grep -v grep | tail -1 | awk '{print $1}'`
-    if [ "X$pid" = "X" ]
+    binforpid=`$READLINK -m "/proc/$pid/exe" | awk '{print $1}'`
+    if [ ! "$binforpid" = "$CMD" ]
     then
         # Process is gone so remove the pid file.
+        pid=""
         rm -f $PIDFILE
     fi
 }

--- a/install/percona-agent
+++ b/install/percona-agent
@@ -112,23 +112,8 @@ REALPATH=`echo $REALPATH | sed -e 's;:; ;g'`
 # Change the current directory to the location of the script
 cd "`dirname "$REALPATH"`"
 
-# Use procfs by default
-USE_PROCFS="yes"
-
-# Detect if we have procfs
-PROCFSPATH=`mount -l -t proc | tail | awk '{print $3}'`
-if [ -z "$PROCFSPATH" ]; then
-     USE_PROCFS="no" 
-fi
-
-# Check for readlink in path, disable procfs if not found
-readlink --version >/dev/null 2>&1
-if [ $? -ne 0 ]; then
-     USE_PROCFS="no" 
-fi
-
 # Check for ps in path
-ps --version >/dev/null 2>&1
+ps >/dev/null 2>&1
 if [ $? -ne 0 ]; then
      echo "Unable to locate 'ps'." >&2
      echo "Please report this with the location on your system." >&2
@@ -157,49 +142,29 @@ getpid() {
       fi
       pid=`cat $PIDFILE`
 	  # Verify that a process with this pid is still running percona-agent
-      if [ $USE_PROCFS = "yes" ]; then
-          binforpid=`readlink -m "$PROCFSPATH/$pid/exe" | awk '{print $1}'`
-          if [ ! "$binforpid" = "$CMD" ]; then
-              pid=""
-          fi
-      else
-          psoutput=`ps -p $pid -o pid,comm | grep $pid | grep -v grep | tail -1` 
-          pid=`echo "$psoutput" | awk '{print $1}'`
-          # Make sure $SERVICE shows up in command name
-          match=`echo "$psoutput" | awk '{print $2}' | grep "$SERVICE"`
-          if [ -z "$match" ]; then
-              pid=""
-          fi
-      fi
-
-      if [ -z "$pid" ]; then
+      psoutput=`ps -p "$pid" -o pid,comm | grep "$pid" | tail -1` 
+      pid=`echo "$psoutput" | awk '{print $1}'`
+      # Make sure $SERVICE shows up in command name
+      match=`echo "$psoutput" | awk '{print $2}' | grep "$SERVICE"`
+      if [ -z "$match" ]; then
+         pid=""
          # This is a stale pid file.
-         rm -f $PIDFILE
+         rm -f "$PIDFILE"
          echo "Removed stale pid file: $PIDFILE"
       fi
    fi
 }
 
 testpid() {
-    if [ $USE_PROCFS = "yes" ]; then
-        binforpid=`readlink -m "/proc/$pid/exe" | awk '{print $1}'`
-        if [ ! "$binforpid" = "$CMD" ]; then
-            # Process is gone reset pid var
-            pid=""
-        fi
-    else
-        psoutput=`ps -p $pid -o pid,comm | grep $pid | grep -v grep | tail -1` 
-        pid=`echo "$psoutput" | awk '{print $1}'`
-        # Make sure $SERVICE shows up in command name
-        match=`echo "$psoutput" | awk '{print $2}' | grep "$SERVICE"`
-        if [ -z "$match" ]; then
-           pid="" 
-        fi
-    fi
-
-    if [ -z "$pid" ]; then
-         # This is a stale pid file.
-         rm -f $PIDFILE
+	# Verify that a process with this pid is still running percona-agent
+    psoutput=`ps -p "$pid" -o pid,comm | grep "$pid" | tail -1` 
+    pid=`echo "$psoutput" | awk '{print $1}'`
+    # Make sure $SERVICE shows up in command name
+    match=`echo "$psoutput" | awk '{print $2}' | grep "$SERVICE"`
+    if [ -z "$match" ]; then
+       pid=""
+       # This is a stale pid file.
+       rm -f "$PIDFILE"
     fi
 }
 

--- a/install/percona-agent_test.go
+++ b/install/percona-agent_test.go
@@ -41,7 +41,6 @@ type MainTestSuite struct {
 	cmd        *exec.Cmd
 	basedir    string
 	bin        string
-	anotherbin string
 	initscript string
 	username   string
 }

--- a/install/percona-agent_test.go
+++ b/install/percona-agent_test.go
@@ -1,0 +1,307 @@
+/*
+   Copyright (c) 2015, Percona LLC and/or its affiliates. All rights reserved.
+
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU Affero General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU Affero General Public License for more details.
+
+   You should have received a copy of the GNU Affero General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>
+*/
+
+package install
+
+import (
+	"fmt"
+	"io/ioutil"
+	"math/rand"
+	"os"
+	"os/exec"
+	"os/user"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/percona/percona-agent/pct"
+	. "gopkg.in/check.v1"
+)
+
+func Test(t *testing.T) { TestingT(t) }
+
+type MainTestSuite struct {
+	cmd        *exec.Cmd
+	basedir    string
+	bin        string
+	anotherbin string
+	initscript string
+	username   string
+}
+
+const (
+	MOCKED_PERCONA_AGENT = "github.com/percona/percona-agent/install/mock"
+)
+
+var _ = Suite(&MainTestSuite{})
+
+func resetTestEnvVars(s *MainTestSuite) {
+	// Sadly no os.Unsetenv in Go 1.3.3
+	os.Setenv("TEST_PERCONA_AGENT_START_DELAY", "")
+	os.Setenv("TEST_PERCONA_AGENT_STOP_DELAY", "")
+	os.Setenv("PERCONA_AGENT_START_TIMEOUT", "")
+	os.Setenv("PERCONA_AGENT_STOP_TIMEOUT", "")
+	os.Setenv("PERCONA_AGENT_USER", s.username)
+	os.Setenv("PERCONA_AGENT_DIR", s.basedir)
+}
+
+func (s *MainTestSuite) SetUpSuite(t *C) {
+	var err error
+
+	// We can't/shouldn't use /usr/local/percona/ (the default basedir), so use
+	// a tmpdir instead with only a bin dir inside
+	s.basedir, err = ioutil.TempDir("/tmp", "percona-agent-init-test-")
+	t.Assert(err, IsNil)
+	err = os.Mkdir(filepath.Join(s.basedir, pct.BIN_DIR), 0777)
+	t.Assert(err, IsNil)
+
+	// Lets compile and place the fake percona-agent on the tmp basedir
+	s.bin = filepath.Join(s.basedir, pct.BIN_DIR, "percona-agent")
+	cmd := exec.Command("go", "build", "-o", s.bin, MOCKED_PERCONA_AGENT)
+	err = cmd.Run()
+	// Failed to compile mocked percona-agent
+	t.Assert(err, IsNil, Commentf("Failed to build mocked percona agent: %v", err))
+
+	user, erruser := user.Current()
+	t.Assert(erruser, IsNil, Commentf("Failed to obtain current user: %v", err))
+	s.username = user.Username
+	initscript, err := filepath.Abs("./percona-agent")
+	// Check if absolute path resolving succedeed
+	t.Assert(err, IsNil)
+	// Check if init script is there
+	t.Assert(pct.FileExists(initscript), Equals, true)
+	s.initscript = filepath.Join(s.basedir, pct.BIN_DIR, "init-script")
+	cmd = exec.Command("cp", initscript, s.initscript)
+	err = cmd.Run()
+	t.Assert(err, IsNil, Commentf("Failed to copy init script to tmp dir: %v", err))
+	resetTestEnvVars(s)
+}
+
+func (s *MainTestSuite) SetUpTest(t *C) {
+	// Clean env vars
+	os.Remove(filepath.Join(s.basedir, "percona-agent.pid"))
+}
+
+func (s *MainTestSuite) TearDownTest(t *C) {
+	// Delete any left pid file and set mocked agent start delay to 0
+	resetTestEnvVars(s)
+	os.Remove(filepath.Join(s.basedir, "percona-agent.pid"))
+}
+
+func (s *MainTestSuite) TearDownSuite(t *C) {
+	// Delete tmp
+	if err := os.RemoveAll(s.basedir); err != nil {
+		t.Error(err)
+	}
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// Helper functions
+///////////////////////////////////////////////////////////////////////////////
+
+func writePidFile(filePath, pid string) error {
+	flags := os.O_CREATE | os.O_EXCL | os.O_WRONLY
+	file, err := os.OpenFile(filePath, flags, 0644)
+	if err != nil {
+		//Could not create pidfile
+		return err
+	}
+	// Pollulate pidfile with valid PID but not corresponding to a fake percona-agent instance
+	if _, err := file.WriteString(pid); err != nil {
+		// Could not write to stale pidfile
+		return err
+	}
+	file.Close()
+	return nil
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// Init script test suite
+///////////////////////////////////////////////////////////////////////////////
+
+func (s *MainTestSuite) TestStatusNoAgent(t *C) {
+	cmd := exec.Command(s.initscript, "status")
+	output, err := cmd.Output()
+	// status exit code should be 1
+	t.Check(err, NotNil)
+	// script should output a message
+	t.Assert(string(output), Equals, "percona-agent is not running.\n")
+}
+
+func (s *MainTestSuite) TestStopNoAgent(t *C) {
+	cmd := exec.Command(s.initscript, "stop")
+	output, err := cmd.Output()
+	// stop exit code should be 0
+	t.Check(err, IsNil)
+	// script should output a message
+	t.Assert(string(output), Equals, "Stopping percona-agent...\npercona-agent is not running.\n")
+}
+
+func (s *MainTestSuite) TestStartStop(t *C) {
+	// Start service
+	cmd := exec.Command(s.initscript, "start")
+	output, err := cmd.Output()
+	// start exit code should be 0
+	t.Check(err, IsNil)
+	// script should output a message
+	t.Assert(string(output), Equals, "Starting percona-agent...\nWaiting for percona-agent to start...\nOK\n")
+
+	// Check status
+	cmd = exec.Command(s.initscript, "status")
+	output, err = cmd.Output()
+	// status exit code should be 1
+	t.Check(err, IsNil)
+	// script should output a message
+	rePID := regexp.MustCompile(`^percona-agent\ is\ running\ \((\d+)\)\.`)
+	found := rePID.FindStringSubmatch(string(output))
+	// Check if the command provided a PID
+	var pid string
+	if len(found) == 2 {
+		pid = found[1]
+	} else {
+		t.Error("Could not get pid for mocked percona-agent")
+	}
+
+	pidbinary, err := os.Readlink(fmt.Sprintf("/proc/%v/exe", pid))
+	// Check that PID actually points to our fake percona-agent binary
+	t.Assert(pidbinary, Equals, s.bin)
+
+	// Now try to stop
+	cmd = exec.Command(s.initscript, "stop")
+	output, err = cmd.Output()
+	// stop exit code should be 0
+	t.Check(err, IsNil)
+	// script should output a message
+	t.Assert(string(output), Equals, "Stopping percona-agent...\nWaiting for percona-agent to exit...\nStopped percona-agent.\n")
+}
+
+func (s *MainTestSuite) TestDoubleStart(t *C) {
+	// Start service
+	cmd := exec.Command(s.initscript, "start")
+	output, err := cmd.Output()
+	// start exit code should be 0
+	t.Check(err, IsNil)
+	// script should output a message
+	t.Assert(string(output), Equals, "Starting percona-agent...\nWaiting for percona-agent to start...\nOK\n")
+
+	// Start service again
+	cmd = exec.Command(s.initscript, "start")
+	output, err = cmd.Output()
+	// start exit code should be 0
+	t.Check(err, IsNil)
+	// script should output a message
+	t.Assert(string(output), Equals, "Starting percona-agent...\npercona-agent is already running.\n")
+}
+
+func (s *MainTestSuite) TestWrongBin(t *C) {
+	pidFilePath := filepath.Join(s.basedir, "percona-agent.pid")
+	if err := writePidFile(pidFilePath, string(os.Getpid())); err != nil {
+		t.Errorf("Could not create pidfile: %v", err)
+	}
+
+	// Now start service
+	cmd := exec.Command(s.initscript, "start")
+	output, err := cmd.Output()
+	// start exit code should be 0
+	t.Check(err, IsNil)
+	// script should output a message
+	t.Assert(string(output), Equals, fmt.Sprintf("Starting percona-agent...\nRemoved stale pid file: %v\nWaiting for "+
+		"percona-agent to start...\nOK\n", pidFilePath))
+}
+
+func (s *MainTestSuite) TestStalePIDFile(t *C) {
+	pidFilePath := filepath.Join(s.basedir, "percona-agent.pid")
+	if err := writePidFile(pidFilePath, string(rand.Uint32())); err != nil {
+		t.Errorf("Could not create pidfile: %v", err)
+	}
+
+	// Now start service
+	cmd := exec.Command(s.initscript, "start")
+	output, err := cmd.Output()
+	// start exit code should be 0
+	t.Check(err, IsNil)
+	// script should output a message
+	t.Assert(string(output), Equals, fmt.Sprintf("Starting percona-agent...\nRemoved stale pid file: %v\nWaiting for "+
+		"percona-agent to start...\nOK\n", pidFilePath))
+}
+
+func (s *MainTestSuite) TestEnvVariables(t *C) {
+	// Set percona-agent user to run with nobody
+	os.Setenv("PERCONA_AGENT_USER", "nobody")
+	// Now start service
+	cmd := exec.Command(s.initscript, "start")
+	output, err := cmd.Output()
+	// start exit code should be 1
+	t.Check(err, NotNil)
+	// script should output no message TODO: check this
+	t.Check(string(output), Equals, "")
+
+	// Set to percona-agent basedir to non existant directory
+	os.Setenv("PERCONA_AGENT_DIR", filepath.Join("/tmp", string(rand.Uint32())))
+	// Now start service
+	cmd = exec.Command(s.initscript, "start")
+	output, err = cmd.Output()
+	// start exit code should be 1
+	t.Check(err, NotNil)
+	// script should output no message TODO: check this
+	t.Check(string(output), Equals, "")
+}
+
+func (s *MainTestSuite) TestDelayedStart(t *C) {
+	// Set percona-agent start delay to 10 seconds
+	os.Setenv("PERCONA_AGENT_START_TIMEOUT", "1")
+	os.Setenv("TEST_PERCONA_AGENT_START_DELAY", "2")
+	// Now try to start service
+	cmd := exec.Command(s.initscript, "start")
+	output, err := cmd.Output()
+	// start exit code should be 1
+	t.Check(err, NotNil)
+	// path to log file, its part of the output
+	perconaLogPath := filepath.Join(s.basedir, "percona-agent.log")
+	// script should output message
+	t.Check(string(output), Equals, fmt.Sprintf("Starting percona-agent...\nWaiting for percona-agent to start...\nFail.  "+
+		"Check %v for details.\n", perconaLogPath))
+}
+
+func (s *MainTestSuite) TestDelayedStop(t *C) {
+	// Set percona-agent start delay to 10 seconds
+	os.Setenv("PERCONA_AGENT_STOP_TIMEOUT", "1")
+	os.Setenv("TEST_PERCONA_AGENT_STOP_DELAY", "2")
+	// Now try to start service
+	cmd := exec.Command(s.initscript, "start")
+	output, err := cmd.Output()
+	// start exit code should be 0
+	t.Check(err, IsNil)
+
+	// Get the PID from the pidfile
+	bytes, err := ioutil.ReadFile(filepath.Join(s.basedir, "percona-agent.pid"))
+	pid := strings.Replace(string(bytes), "\n", "", -1)
+	// check if we could read the pidfile
+	t.Check(err, IsNil)
+
+	stop_cmd := exec.Command(s.initscript, "stop")
+	output, err = stop_cmd.Output()
+	// start exit code should be 1
+	t.Check(err, IsNil)
+
+	// script should output message
+	t.Check(string(output), Equals, fmt.Sprintf("Stopping percona-agent...\nWaiting for percona-agent to exit...\n"+
+		"Time out waiting for percona-agent to exit.  Trying kill -9 %v...\nStopped percona-agent.\n", pid))
+	// Make sure the process was killed
+	t.Assert(pct.FileExists(fmt.Sprintf("/proc/%v/stat", pid)), Equals, false)
+}

--- a/install/percona-agent_test.go
+++ b/install/percona-agent_test.go
@@ -104,6 +104,7 @@ func (s *MainTestSuite) TearDownTest(t *C) {
 
 func (s *MainTestSuite) TearDownSuite(t *C) {
 	// Delete tmp
+	return
 	if err := os.RemoveAll(s.basedir); err != nil {
 		t.Error(err)
 	}
@@ -111,12 +112,12 @@ func (s *MainTestSuite) TearDownSuite(t *C) {
 
 func resetTestEnvVars(s *MainTestSuite) {
 	// Sadly no os.Unsetenv in Go 1.3.x
-	os.Setenv("TEST_PERCONA_AGENT_START_DELAY", "")
-	os.Setenv("TEST_PERCONA_AGENT_STOP_DELAY", "")
-	os.Setenv("PERCONA_AGENT_START_TIMEOUT", "")
-	os.Setenv("PERCONA_AGENT_STOP_TIMEOUT", "")
-	os.Setenv("PERCONA_AGENT_USER", s.username)
-	os.Setenv("PERCONA_AGENT_DIR", s.basedir)
+	os.Setenv("PCT_TEST_START_DELAY", "")
+	os.Setenv("PCT_TEST_STOP_DELAY", "")
+	os.Setenv("PCT_TEST_START_TIMEOUT", "")
+	os.Setenv("PCT_TEST_STOP_TIMEOUT", "")
+	os.Setenv("PCT_TEST_AGENT_USER", s.username)
+	os.Setenv("PCT_TEST_AGENT_DIR", s.basedir)
 }
 
 func writePidFile(filePath, pid string) error {
@@ -254,33 +255,11 @@ func (s *MainTestSuite) TestStalePIDFile(t *C) {
 		"percona-agent to start...\nOK\n", pidFilePath))
 }
 
-func (s *MainTestSuite) TestEnvVariables(t *C) {
-	// Set percona-agent user to run with nobody
-	os.Setenv("PERCONA_AGENT_USER", "nobody")
-	// Now start service
-	cmd := exec.Command(s.initscript, "start")
-	output, err := cmd.Output()
-	// start exit code should be 1
-	t.Check(err, NotNil)
-	// script should output no message TODO: check this
-	t.Check(string(output), Equals, "")
-
-	// Set to percona-agent basedir to non existant directory
-	os.Setenv("PERCONA_AGENT_DIR", filepath.Join(s.basedir, string(rand.Uint32())))
-	// Try to start service
-	cmd = exec.Command(s.initscript, "start")
-	output, err = cmd.Output()
-	// start exit code should be 1
-	t.Check(err, NotNil)
-	// script should output no message TODO: check this
-	t.Check(string(output), Equals, "")
-}
-
 func (s *MainTestSuite) TestDelayedStart(t *C) {
 	// Set init script timeout to 1 second
-	os.Setenv("PERCONA_AGENT_START_TIMEOUT", "1")
+	os.Setenv("PCT_TEST_START_TIMEOUT", "1")
 	// Set percona-agent start delay to 2 seconds
-	os.Setenv("TEST_PERCONA_AGENT_START_DELAY", "2")
+	os.Setenv("PCT_TEST_START_DELAY", "2")
 	// Now try to start service
 	cmd := exec.Command(s.initscript, "start")
 	output, err := cmd.Output()
@@ -295,9 +274,9 @@ func (s *MainTestSuite) TestDelayedStart(t *C) {
 
 func (s *MainTestSuite) TestDelayedStop(t *C) {
 	// Set init script stop timeout to 1 second
-	os.Setenv("PERCONA_AGENT_STOP_TIMEOUT", "1")
+	os.Setenv("PCT_TEST_STOP_TIMEOUT", "1")
 	// Set percona-agent stop delay to 2 seconds
-	os.Setenv("TEST_PERCONA_AGENT_STOP_DELAY", "2")
+	os.Setenv("PCT_TEST_STOP_DELAY", "2")
 	// Now try to start service
 	cmd := exec.Command(s.initscript, "start")
 	output, err := cmd.Output()

--- a/install/percona-agent_test.go
+++ b/install/percona-agent_test.go
@@ -104,7 +104,6 @@ func (s *MainTestSuite) TearDownTest(t *C) {
 
 func (s *MainTestSuite) TearDownSuite(t *C) {
 	// Delete tmp
-	return
 	if err := os.RemoveAll(s.basedir); err != nil {
 		t.Error(err)
 	}

--- a/install/percona-agent_test.go
+++ b/install/percona-agent_test.go
@@ -261,7 +261,7 @@ func (s *MainTestSuite) TestEnvVariables(t *C) {
 	t.Check(string(output), Equals, "")
 
 	// Set to percona-agent basedir to non existant directory
-	os.Setenv("PERCONA_AGENT_DIR", filepath.Join("/tmp", string(rand.Uint32())))
+	os.Setenv("PERCONA_AGENT_DIR", filepath.Join(s.basedir, string(rand.Uint32())))
 	// Try to start service
 	cmd = exec.Command(s.initscript, "start")
 	output, err = cmd.Output()

--- a/install/percona-agent_test.go
+++ b/install/percona-agent_test.go
@@ -104,10 +104,6 @@ func (s *MainTestSuite) TearDownSuite(t *C) {
 	}
 }
 
-///////////////////////////////////////////////////////////////////////////////
-// Helper functions
-///////////////////////////////////////////////////////////////////////////////
-
 func resetTestEnvVars(s *MainTestSuite) {
 	// Sadly no os.Unsetenv in Go 1.3.x
 	os.Setenv("TEST_PERCONA_AGENT_START_DELAY", "")
@@ -143,9 +139,7 @@ func readPidFile(pidFilePath string) (pid string, err error) {
 	}
 }
 
-///////////////////////////////////////////////////////////////////////////////
-// Init script test suite
-///////////////////////////////////////////////////////////////////////////////
+//-----------------------------------------------------------------------------
 
 func (s *MainTestSuite) TestStatusNoAgent(t *C) {
 	cmd := exec.Command(s.initscript, "status")

--- a/install/percona-agent_test.go
+++ b/install/percona-agent_test.go
@@ -44,6 +44,7 @@ type MainTestSuite struct {
 	anotherbin string
 	initscript string
 	username   string
+	origpath   string
 }
 
 const (
@@ -69,9 +70,12 @@ func (s *MainTestSuite) SetUpSuite(t *C) {
 	// Failed to compile mocked percona-agent
 	t.Assert(err, IsNil, Commentf("Failed to build mocked percona agent: %v", err))
 
+	// Get current username to set test env variable
 	user, erruser := user.Current()
 	t.Assert(erruser, IsNil, Commentf("Failed to obtain current user: %v", err))
 	s.username = user.Username
+
+	// Copy init script to tmp basedir/bin directory
 	initscript, err := filepath.Abs("./percona-agent")
 	// Check if absolute path resolving succedeed
 	t.Assert(err, IsNil)
@@ -81,6 +85,22 @@ func (s *MainTestSuite) SetUpSuite(t *C) {
 	cmd = exec.Command("cp", initscript, s.initscript)
 	err = cmd.Run()
 	t.Assert(err, IsNil, Commentf("Failed to copy init script to tmp dir: %v", err))
+
+	// Store original PATH in test suite
+	s.origpath = os.Getenv("PATH")
+
+	// Create mock dir to store mocked mount command
+	err = os.Mkdir(filepath.Join(s.basedir, "mock"), 0777)
+	// Creates a fake mount sh command that will always fail
+	flags := os.O_CREATE | os.O_EXCL | os.O_WRONLY
+	file, errf := os.OpenFile(filepath.Join(s.basedir, "mock", "mount"), flags, 0777)
+	t.Assert(errf, IsNil, Commentf("Could not create mocked mount file: %v", err))
+	// Write empty shell script to make mount cmd always fail
+	_, errw := file.WriteString("#!/bin/sh\nexit 1")
+	t.Assert(errw, IsNil, Commentf("Could not write to mocked mount: %v", err))
+	file.Close()
+
+	// Set all env vars to default test values
 	resetTestEnvVars(s)
 }
 
@@ -106,6 +126,7 @@ func (s *MainTestSuite) TearDownSuite(t *C) {
 
 func resetTestEnvVars(s *MainTestSuite) {
 	// Sadly no os.Unsetenv in Go 1.3.x
+	os.Setenv("PATH", s.origpath)
 	os.Setenv("TEST_PERCONA_AGENT_START_DELAY", "")
 	os.Setenv("TEST_PERCONA_AGENT_STOP_DELAY", "")
 	os.Setenv("PERCONA_AGENT_START_TIMEOUT", "")
@@ -316,4 +337,18 @@ func (s *MainTestSuite) TestDelayedStop(t *C) {
 		"Time out waiting for percona-agent to exit.  Trying kill -9 %v...\nStopped percona-agent.\n", pid))
 	// Make sure the process was killed
 	t.Assert(pct.FileExists(fmt.Sprintf("/proc/%v/stat", pid)), Equals, false)
+}
+
+func (s *MainTestSuite) TestStartStopNoProcfs(t *C) {
+	// Lets set PATH so our mocked mount is found first
+	os.Setenv("PATH", filepath.Join(s.basedir, "mock")+":"+s.origpath)
+	// Lets run the same test as with procfs to see if everything still works
+	s.TestStartStop(t)
+}
+
+func (s *MainTestSuite) TestWrongBinNoProcfs(t *C) {
+	// Lets set PATH so our mocked mount is found first
+	os.Setenv("PATH", filepath.Join(s.basedir, "mock")+":"+s.origpath)
+	// Lets run same test as with procfs to see if everything still works
+	s.TestWrongBin(t)
 }


### PR DESCRIPTION
Checking for the name of percona-agent in the output of ps using pid as parameter was all that was needed to make this happen.  A refactor was also done to make the script more readable.

Since there were no automated tests for this script, I included general tests for the entire script and the test for the bug fix, all written in golang/gocheck. I tried several shell unit-test frameworks first (assert.sh, shunit, shunit2) none was convincing.

To make the init script testable I had to introduce some environment variables to be able to make it behave in different ways, all variables hold defaults values equal to previous hardcoded ones:

- PCT_TEST_AGENT_USER: Owner of percona-agent basedir (default `root`)
- PCT_TEST_AGENT_DIR: aka basedir (default `/usr/local/percona/percona-agent`)
- PCT_TEST_START_DELAY: How many seconds to wait for percona-agent process to start (default: `5`)
- PCT_TEST_STOP_DELAY: How many seconds to wait for percona-agent process to stop (default: `60`)