### PR TITLE
PCT-1161 Agent report crashing

### DIFF
--- a/Godeps.json
+++ b/Godeps.json
@@ -20,7 +20,7 @@
 		},
 		{
 			"Pkg": "github.com/percona/go-mysql",
-			"Rev": "1346a81058f6b6a7b74a84b214c3ce65c0e4de29"
+			"Rev": "d5462716ca30f11f4a6e50e35f07ebb6844c7e3d"
 		},
 		{
 			"Pkg": "github.com/petar/GoLLRB",


### PR DESCRIPTION
slow.log parser was failing when the log had an invalid # Time or # User line.
This commit only updates Godep.json to make it point to the latest go-mysql commit

CI-Tools: http://tools-ci.percona.com/job/percona-agent-branch/178/console
go-mysql PR: https://github.com/percona/go-mysql/pull/5/files