### PR TITLE
PCT 805 test fix

### DIFF
--- a/install/percona-agent
+++ b/install/percona-agent
@@ -131,11 +131,11 @@ remove_stale_pidfile() {
     # if succeeds echo optional $1 parameter
     # Note: rm will always exit with status 0
     found="no"
-    if [ -f $PIDFILE ]; then
+    if [ -f "$PIDFILE" ]; then
         found="yes"
     fi
     rm -f "$PIDFILE"
-    if [ $found = "yes" ] && [ ! -f $PIDFILE ] && [ -n "$1" ]; then
+    if [ $found = "yes" ] && [ ! -f "$PIDFILE" ] && [ -n "$1" ]; then
         # If file was actually deleted and a message to display was provided
         echo "$1"
     fi
@@ -143,16 +143,16 @@ remove_stale_pidfile() {
 
 get_pid_from_file() {
    PID=""
-   if [ ! -f $PIDFILE ]; then
+   if [ ! -f "$PIDFILE" ]; then
       return 1
    fi
 
-   if [ ! -r $PIDFILE ]; then
+   if [ ! -r "$PIDFILE" ]; then
       echo "Cannot read $PIDFILE." >&2
       exit 1
    fi
 
-   PID=`cat $PIDFILE`
+   PID=`cat "$PIDFILE"`
    return 0
 }
 

--- a/install/percona-agent
+++ b/install/percona-agent
@@ -119,7 +119,7 @@ is_pid_running_agent() {
         # ps does not like empty string as pid
         return 1
     fi
-    match=`ps -p "$PID" -o comm | grep -o "$SERVICE"`
+    match=`ps -p "$PID" -o comm 2>/dev/null | grep -o "$SERVICE"`
     if [ -z "$match" ]; then
        return 1
     fi


### PR DESCRIPTION
This fix addresses the problem with current init script tests. The scenario was difficult to replicate as it only happened sometimes, in my local dev env it happened 1 time out of 10-15 test runs.

The problem was basically test setup. Using the same tmp basedir for all tests, even after cleaning it from generated files, could lead to disappearing of pid files at any given time. This happens because KILL/TERM of mocked agent will remove the pidfile as part of its shutdown procedure to avoid leaving files behind. This makes some tests fail if they expect to find a pidfile and the file is removed between the time the test creates it and checks for its existence. This should be more evident in slower or busier machines, which could also explain why it happened more on CI (but not always) and not so much on local dev env.

This PR fixes this test environment isolation issue by simply creating an new env for every test but avoiding recompiling the mocked agent to keep test times as down as possible.

