### PR TITLE
PCT-540 Agent does not support old password authentication

### DIFF
--- a/bin/percona-agent-installer/installer/mysql.go
+++ b/bin/percona-agent-installer/installer/mysql.go
@@ -38,7 +38,10 @@ func MakeGrant(dsn mysql.DSN, user string, pass string, mysqlMaxUserConns int64)
 	} else if dsn.Hostname == "127.0.0.1" {
 		host = "127.0.0.1"
 	}
+	// Creating/updating a user's password doesn't work correctly if old_passwords is active.
+	// Just in case, disable it for this session
 	grants := []string{
+		"SET SESSION old_passwords=0",
 		fmt.Sprintf("GRANT SUPER, PROCESS, USAGE, SELECT ON *.* TO '%s'@'%s' IDENTIFIED BY '%s' WITH MAX_USER_CONNECTIONS %d", user, host, pass, mysqlMaxUserConns),
 		fmt.Sprintf("GRANT UPDATE, DELETE, DROP ON performance_schema.* TO '%s'@'%s' IDENTIFIED BY '%s' WITH MAX_USER_CONNECTIONS %d", user, host, pass, mysqlMaxUserConns),
 	}

--- a/bin/percona-agent-installer/installer/mysql_test.go
+++ b/bin/percona-agent-installer/installer/mysql_test.go
@@ -47,6 +47,7 @@ func (s *MySQLTestSuite) TestMakeGrant(t *C) {
 	maxOpenConnections := int64(1)
 	got := i.MakeGrant(dsn, user, pass, maxOpenConnections)
 	expect := []string{
+		"SET SESSION old_passwords=0",
 		"GRANT SUPER, PROCESS, USAGE, SELECT ON *.* TO 'new-user'@'localhost' IDENTIFIED BY 'some pass' WITH MAX_USER_CONNECTIONS 1",
 		"GRANT UPDATE, DELETE, DROP ON performance_schema.* TO 'new-user'@'localhost' IDENTIFIED BY 'some pass' WITH MAX_USER_CONNECTIONS 1",
 	}
@@ -64,6 +65,7 @@ func (s *MySQLTestSuite) TestMakeGrant(t *C) {
 	dsn.Hostname = "10.1.1.1"
 	got = i.MakeGrant(dsn, user, pass, maxOpenConnections)
 	expect = []string{
+		"SET SESSION old_passwords=0",
 		"GRANT SUPER, PROCESS, USAGE, SELECT ON *.* TO 'new-user'@'%' IDENTIFIED BY 'some pass' WITH MAX_USER_CONNECTIONS 1",
 		"GRANT UPDATE, DELETE, DROP ON performance_schema.* TO 'new-user'@'%' IDENTIFIED BY 'some pass' WITH MAX_USER_CONNECTIONS 1",
 	}
@@ -73,6 +75,7 @@ func (s *MySQLTestSuite) TestMakeGrant(t *C) {
 	dsn.Socket = "/var/lib/mysql.sock"
 	got = i.MakeGrant(dsn, user, pass, maxOpenConnections)
 	expect = []string{
+		"SET SESSION old_passwords=0",
 		"GRANT SUPER, PROCESS, USAGE, SELECT ON *.* TO 'new-user'@'localhost' IDENTIFIED BY 'some pass' WITH MAX_USER_CONNECTIONS 1",
 		"GRANT UPDATE, DELETE, DROP ON performance_schema.* TO 'new-user'@'localhost' IDENTIFIED BY 'some pass' WITH MAX_USER_CONNECTIONS 1",
 	}

--- a/bin/percona-agent-installer/installer/mysql_test.go
+++ b/bin/percona-agent-installer/installer/mysql_test.go
@@ -18,11 +18,12 @@
 package installer_test
 
 import (
+	"io/ioutil"
+
 	i "github.com/percona/percona-agent/bin/percona-agent-installer/installer"
 	"github.com/percona/percona-agent/mysql"
 	"github.com/percona/percona-agent/test"
 	. "gopkg.in/check.v1"
-	"io/ioutil"
 )
 
 type MySQLTestSuite struct {
@@ -54,6 +55,7 @@ func (s *MySQLTestSuite) TestMakeGrant(t *C) {
 	dsn.Hostname = "127.0.0.1"
 	got = i.MakeGrant(dsn, user, pass, maxOpenConnections)
 	expect = []string{
+		"SET SESSION old_passwords=0",
 		"GRANT SUPER, PROCESS, USAGE, SELECT ON *.* TO 'new-user'@'127.0.0.1' IDENTIFIED BY 'some pass' WITH MAX_USER_CONNECTIONS 1",
 		"GRANT UPDATE, DELETE, DROP ON performance_schema.* TO 'new-user'@'127.0.0.1' IDENTIFIED BY 'some pass' WITH MAX_USER_CONNECTIONS 1",
 	}


### PR DESCRIPTION
Old password is being disabled before running GRANTs because
if we create/update a user's password while old_passworrds is
enabled, it doesn't work as expected and then the agent is not
able to connect to the db.