### PR TITLE
PCT-1479: Use only one thread

### DIFF
--- a/bin/percona-agent/main.go
+++ b/bin/percona-agent/main.go
@@ -80,7 +80,11 @@ func init() {
 		flag.Usage()
 		os.Exit(1)
 	}
-	runtime.GOMAXPROCS(runtime.NumCPU())
+	// Below condition should allow people to use higher number of threads if they want to
+	if os.Getenv("GOMAXPROCS") == "" {
+		// "1" is currently default in golang but this may change in the future, so let's lock this
+		runtime.GOMAXPROCS(1)
+	}
 }
 
 func run() error {


### PR DESCRIPTION
 Use only one thread to not overload customers servers in case something goes out of control
(requested by Vadim)