### PR TITLE
PCT-1133: Log when agent starts, stops, and its version

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -129,7 +129,7 @@ func (agent *Agent) Run() error {
 	// https://jira.percona.com/browse/PCT-765
 	agent.keepalive = time.NewTicker(time.Duration(agent.config.Keepalive) * time.Second)
 
-	logger.Info(fmt.Sprintf("Started version: %s", VERSION))
+	logger.Info("Started version: " + VERSION)
 
 	for {
 		logger.Debug("idle")

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -129,7 +129,7 @@ func (agent *Agent) Run() error {
 	// https://jira.percona.com/browse/PCT-765
 	agent.keepalive = time.NewTicker(time.Duration(agent.config.Keepalive) * time.Second)
 
-	logger.Info("Started")
+	logger.Info(fmt.Sprintf("Started version: %s", VERSION))
 
 	for {
 		logger.Debug("idle")

--- a/bin/percona-agent/main.go
+++ b/bin/percona-agent/main.go
@@ -450,7 +450,8 @@ func run() error {
 	for agentRunning {
 		select {
 		case stopErr = <-stopChan: // agent or signal
-			agentLogger.Info("Agent stopped, shutting down...")
+			agentLogger.Info("Agent stopped")
+			golog.Println("Agent stopped, shutting down...")
 			agentRunning = false
 		case <-statusSigChan:
 			status := agent.AllStatus()

--- a/bin/percona-agent/main.go
+++ b/bin/percona-agent/main.go
@@ -411,9 +411,11 @@ func run() error {
 	// Set the global pct/cmd.Factory, used for the Restart cmd.
 	pctCmd.Factory = &pctCmd.RealCmdFactory{}
 
+	agentLogger := pct.NewLogger(logChan, "agent")
+
 	agent := agent.NewAgent(
 		agentConfig,
-		pct.NewLogger(logChan, "agent"),
+		agentLogger,
 		api,
 		cmdClient,
 		services,
@@ -428,8 +430,7 @@ func run() error {
 		defer func() {
 			if err := recover(); err != nil {
 				errMsg := fmt.Sprintf("Agent crashed: %s", err)
-				logger := pct.NewLogger(logChan, "agent")
-				logger.Error(errMsg)
+				agentLogger.Error(errMsg)
 				stopChan <- fmt.Errorf("%s", errMsg)
 			}
 		}()
@@ -445,7 +446,7 @@ func run() error {
 	for agentRunning {
 		select {
 		case stopErr = <-stopChan: // agent or signal
-			golog.Println("Agent stopped, shutting down...")
+			agentLogger.Info("Agent stopped, shutting down...")
 			agentRunning = false
 		case <-statusSigChan:
 			status := agent.AllStatus()

--- a/bin/percona-agent/main.go
+++ b/bin/percona-agent/main.go
@@ -434,6 +434,7 @@ func run() error {
 		defer func() {
 			if err := recover(); err != nil {
 				errMsg := fmt.Sprintf("Agent crashed: %s", err)
+				golog.Println(errMsg)
 				agentLogger.Error(errMsg)
 				stopChan <- fmt.Errorf("%s", errMsg)
 			}
@@ -450,8 +451,8 @@ func run() error {
 	for agentRunning {
 		select {
 		case stopErr = <-stopChan: // agent or signal
-			agentLogger.Info("Agent stopped")
 			golog.Println("Agent stopped, shutting down...")
+			agentLogger.Info("Agent stopped")
 			agentRunning = false
 		case <-statusSigChan:
 			status := agent.AllStatus()


### PR DESCRIPTION
This adds the agent version to the agent start log, and logs when agent is stopped manually from CLI. 

Right now there is a difference on how stop logs are presented to the user.
If an agent stop is invoked from FE the agent service is stopped and logs are sent to the API. 
If the agent is stopped from CLI then only qan is stopped and no actual log of agent stop is generated (only qan stop logs). This PR changes this behavior and always sends a "Agent stopped, shutting down..." in both stop scenarios.