### PR TITLE
PCT-1438 Added tz diff param for slow log

### DIFF
--- a/Godeps.json
+++ b/Godeps.json
@@ -20,7 +20,7 @@
 		},
 		{
 			"Pkg": "github.com/percona/go-mysql",
-			"Rev": "bbb5030e6dbe065b0c34a924e024f4329c8ba750"
+			"Rev": "2395e1e2cad3d8d6ddb93e9bfceb8386f5db200a"
 		},
 		{
 			"Pkg": "github.com/petar/GoLLRB",

--- a/qan/perfschema/perfschema_test.go
+++ b/qan/perfschema/perfschema_test.go
@@ -284,7 +284,6 @@ func (s *WorkerTestSuite) TestRealWorker(t *C) {
 	// SCHEMA_NAME: NULL
 	//      DIGEST: fbe070dfb47e4a2401c5be6b5201254e
 	// DIGEST_TEXT: SELECT ? FROM DUAL
-	mysqlConn.DB().Exec(`SET time_zone="-1:00"`)
 	_, err = mysqlConn.DB().Exec("SELECT 'teapot' FROM DUAL")
 
 	// First interval.

--- a/qan/perfschema/perfschema_test.go
+++ b/qan/perfschema/perfschema_test.go
@@ -284,6 +284,7 @@ func (s *WorkerTestSuite) TestRealWorker(t *C) {
 	// SCHEMA_NAME: NULL
 	//      DIGEST: fbe070dfb47e4a2401c5be6b5201254e
 	// DIGEST_TEXT: SELECT ? FROM DUAL
+	mysqlConn.DB().Exec(`SET time_zone="-1:00"`)
 	_, err = mysqlConn.DB().Exec("SELECT 'teapot' FROM DUAL")
 
 	// First interval.

--- a/qan/perfschema/worker.go
+++ b/qan/perfschema/worker.go
@@ -520,7 +520,8 @@ CLASS_LOOP:
 		// Create and save the pre-aggregated class.  Using only last 16 digits
 		// of checksum is historical: pt-query-digest does the same:
 		// my $checksum = uc substr(md5_hex($val), -16);
-		class := event.NewQueryClass(classId, class.DigestText, false)
+		// 0 as tzDiff (last param) because we are not saving examples
+		class := event.NewQueryClass(classId, class.DigestText, false, 0)
 		class.TotalQueries = d.CountStar
 		class.Metrics = stats
 		classes = append(classes, class)

--- a/qan/report.go
+++ b/qan/report.go
@@ -104,7 +104,7 @@ func MakeReport(config Config, interval *Interval, result *Result) *Report {
 	report.Class = result.Class[0:config.ReportLimit]
 
 	// Low-ranking Queries
-	lrq := event.NewQueryClass("0", "", false)
+	lrq := event.NewQueryClass("0", "", false, 0*time.Second)
 	for _, query := range result.Class[config.ReportLimit:n] {
 		addQuery(lrq, query)
 	}

--- a/qan/slowlog/slowlog_test.go
+++ b/qan/slowlog/slowlog_test.go
@@ -171,9 +171,6 @@ func (s *WorkerTestSuite) TestWorkerSlow001(t *C) {
 		Dump(got)
 		t.Error(diff)
 	}
-	for _, c := range got.Class {
-		fmt.Printf("Got: %+v\n", c.Example)
-	}
 }
 
 func (s *WorkerTestSuite) TestWorkerSlow001NoExamples(t *C) {

--- a/qan/slowlog/worker.go
+++ b/qan/slowlog/worker.go
@@ -422,8 +422,3 @@ func (w *Worker) rotateSlowLog(interval *qan.Interval) error {
 
 	return nil
 }
-
-// This function is to make tests easier
-func (w *Worker) GetTzDiffUTC() time.Duration {
-	return w.tzDiffUTC
-}


### PR DESCRIPTION
Added TZ diff to solve the first_seen/last_seen problem
By Adding the TZ, we could fix the problem because the original last_seen timestamp was read from the slow_low file (client side) but the first_seen was NOW(). 
If the agent is running in a tz other than UTC, there will be a difference in hours between the first_seen and last_seen