### PR TITLE
PCT-1510 Explain not working for DML queries on MySQL 5.6.3+

### DIFF
--- a/mysql/error.go
+++ b/mysql/error.go
@@ -30,4 +30,5 @@ func FormatError(err error) string {
 const (
 	ER_SPECIFIC_ACCESS_DENIED_ERROR = 1227
 	ER_SYNTAX_ERROR                 = 1064
+	ER_USER_DENIED                  = 1142
 )

--- a/query/service/explain.go
+++ b/query/service/explain.go
@@ -217,7 +217,7 @@ func insertToSelect(matches []string) string {
 		query := fmt.Sprintf("SELECT * FROM %s WHERE ", matches[1])
 		sep := ""
 		for i := 0; i < len(fields); i++ {
-			query = query + fmt.Sprintf(`%s%s="%s"`, sep, strings.TrimSpace(fields[i]), values[i])
+			query = query + fmt.Sprintf(`%s%s=%s`, sep, strings.TrimSpace(fields[i]), values[i])
 			sep = " and "
 		}
 		return query

--- a/query/service/explain.go
+++ b/query/service/explain.go
@@ -77,7 +77,6 @@ func (e *Explain) Handle(cmd *proto.Cmd) *proto.Reply {
 		return cmd.Reply(nil, fmt.Errorf("Unable to create connector for %s: %s", name, err))
 	}
 	defer conn.Close()
-
 	// Connect to MySQL instance
 	if err := conn.Connect(2); err != nil {
 		return cmd.Reply(nil, fmt.Errorf("Unable to connect to %s: %s", name, err))
@@ -86,7 +85,12 @@ func (e *Explain) Handle(cmd *proto.Cmd) *proto.Reply {
 	// Run explain
 	explain, err := conn.Explain(explainQuery.Query, explainQuery.Db)
 	if err != nil {
-		if mysql.MySQLErrorCode(err) == mysql.ER_SYNTAX_ERROR {
+		// MySQL 5.5 will return Syntax error because it doesn't support
+		// explains on DML queries
+		// MySQL 5.6.3+ supports explains on DML queries, but it requieres
+		// additional privileges
+		if mysql.MySQLErrorCode(err) == mysql.ER_SYNTAX_ERROR ||
+			mysql.MySQLErrorCode(err) == mysql.ER_USER_DENIED {
 			if e.isDMLQuery(explainQuery.Query) {
 				newQuery := e.DMLToSelect(explainQuery.Query)
 				if newQuery == "" {

--- a/query/service/explain_test.go
+++ b/query/service/explain_test.go
@@ -20,6 +20,12 @@ package service_test
 import (
 	"database/sql"
 	"encoding/json"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
 	"github.com/percona/cloud-protocol/proto"
 	"github.com/percona/percona-agent/instance"
 	"github.com/percona/percona-agent/mysql"
@@ -28,11 +34,6 @@ import (
 	"github.com/percona/percona-agent/query/service"
 	"github.com/percona/percona-agent/test/mock"
 	. "gopkg.in/check.v1"
-	"io/ioutil"
-	"os"
-	"path/filepath"
-	"testing"
-	"time"
 )
 
 // Hook up gocheck into the "go test" runner.
@@ -351,7 +352,7 @@ func (s *ManagerTestSuite) TestDMLToSelect(t *C) {
 	t.Assert(selQuery, Equals, `SELECT 1 FROM tabla join tabla2 on tabla.id = tabla2.tabla2_id`)
 
 	selQuery = e.DMLToSelect(`insert into tabla (f1, f2, f3) values (1,2,3)`)
-	t.Assert(selQuery, Equals, `SELECT * FROM tabla  WHERE f1="1" and f2="2" and f3="3"`)
+	t.Assert(selQuery, Equals, `SELECT * FROM tabla  WHERE f1=1 and f2=2 and f3=3`)
 
 	selQuery = e.DMLToSelect(`insert into tabla (f1, f2, f3) values (1,2)`)
 	t.Assert(selQuery, Equals, `SELECT * FROM tabla  LIMIT 1`)


### PR DESCRIPTION
On MySQL 5.6.3+, running an explain on DML queries requires special privileges.
The original fix, PCT-1054 was made when 5.6.3 was not available so it was checking only for SYNTAX ERROR. Now it checks for sysntax error and permission denied to determine is the query should be converted to the equivalent SELECT.
Also fixed a conversion from INSERT to SELECT using string parameters