### PR TITLE
PCT-1619 Agent panicking on null digest in perf schema

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -1,4 +1,7 @@
 percona-agent Changelog
+v1.0.13 released 2015-04-21
+  * Updated diskv package to avoid potential goroutine leaks
+  * PCT-1619 Support for NULL digests in perf schema events_statements_summary_by_digest table
 
 v1.0.12 released 2015-04-08
 

--- a/qan/perfschema/perfschema_test.go
+++ b/qan/perfschema/perfschema_test.go
@@ -250,6 +250,32 @@ func (s *WorkerTestSuite) Test002(t *C) {
 	t.Assert(err, IsNil)
 }
 
+func (s *WorkerTestSuite) TestEmptyDigest(t *C) {
+	// This is the simplest input possible: 1 query in iter 1 and 2. The result
+	// is just the increase in its values.
+
+	rows, err := s.loadData("004")
+	t.Assert(err, IsNil)
+	getRows := makeGetRowsFunc(rows)
+	getText := makeGetTextFunc("select 1")
+	w := perfschema.NewWorker(s.logger, s.nullmysql, getRows, getText)
+
+	// First run doesn't produce a result because 2 snapshots are required.
+	i := &qan.Interval{
+		Number:    1,
+		StartTime: time.Now().UTC(),
+	}
+	err = w.Setup(i)
+	t.Assert(err, IsNil)
+
+	res, err := w.Run()
+	t.Assert(err, IsNil)
+	t.Check(res, IsNil)
+
+	err = w.Cleanup()
+	t.Assert(err, IsNil)
+
+}
 func (s *WorkerTestSuite) TestRealWorker(t *C) {
 	if s.dsn == "" {
 		t.Fatal("PCT_TEST_MYSQL_DSN is not set")

--- a/qan/perfschema/worker.go
+++ b/qan/perfschema/worker.go
@@ -351,8 +351,10 @@ ROW_LOOP:
 					var err error
 					digestText, err = w.getText(row.Digest)
 					if classId == "NULL" && digestText == "" {
-						digestText = "perf_schema_tables_full"
+						// To make explains works
+						digestText = `SELECT "perf_schema_tables_are_full"`
 					}
+					fmt.Println(digestText)
 					if err != nil {
 						w.logger.Error(err)
 						continue

--- a/qan/perfschema/worker.go
+++ b/qan/perfschema/worker.go
@@ -324,7 +324,13 @@ ROW_LOOP:
 		select {
 		case row := <-rowChan:
 			w.lastRowCnt++
-			classId := "0000000000000000"
+			// If events_statements_summary_by_digest is full, MySQL will start
+			// setting the digest to NULL and will only compute a summary under that
+			// null digest.
+			// http://dev.mysql.com/doc/refman/5.6/en/statement-summary-tables.html#idm140190647360848
+			// In that case, we set the digest to the string NULL to support this
+			// summary in PCT
+			classId := "NULL"
 			if len(row.Digest) >= 32 {
 				classId = strings.ToUpper(row.Digest[16:32])
 			}

--- a/qan/perfschema/worker.go
+++ b/qan/perfschema/worker.go
@@ -350,6 +350,9 @@ ROW_LOOP:
 					// Have never seen class before, so get digext text from perf schema.
 					var err error
 					digestText, err = w.getText(row.Digest)
+					if classId == "NULL" && digestText == "" {
+						digestText = "perf_schema_tables_full"
+					}
 					if err != nil {
 						w.logger.Error(err)
 						continue

--- a/qan/perfschema/worker.go
+++ b/qan/perfschema/worker.go
@@ -328,9 +328,9 @@ ROW_LOOP:
 			// setting the digest to NULL and will only compute a summary under that
 			// null digest.
 			// http://dev.mysql.com/doc/refman/5.6/en/statement-summary-tables.html#idm140190647360848
-			// In that case, we set the digest to the string NULL to support this
-			// summary in PCT
-			classId := "NULL"
+			// In that case, we set the digest to the string "2" (1 if for LRQ) to support
+			// this summary in PCT
+			classId := "2"
 			if len(row.Digest) >= 32 {
 				classId = strings.ToUpper(row.Digest[16:32])
 			}
@@ -350,9 +350,9 @@ ROW_LOOP:
 					// Have never seen class before, so get digext text from perf schema.
 					var err error
 					digestText, err = w.getText(row.Digest)
-					if classId == "NULL" && digestText == "" {
+					if classId == "2" && digestText == "" {
 						// To make explains works
-						digestText = `SELECT "perf_schema_tables_are_full"`
+						digestText = `-- performance_schema.events_statements_summary_by_digest is full`
 					}
 					if err != nil {
 						w.logger.Error(err)

--- a/qan/perfschema/worker.go
+++ b/qan/perfschema/worker.go
@@ -324,7 +324,10 @@ ROW_LOOP:
 		select {
 		case row := <-rowChan:
 			w.lastRowCnt++
-			classId := strings.ToUpper(row.Digest[16:32])
+			classId := "0000000000000000"
+			if len(row.Digest) >= 32 {
+				classId = strings.ToUpper(row.Digest[16:32])
+			}
 			if class, haveClass := curr[classId]; haveClass {
 				if _, haveRow := class.Rows[row.Schema]; haveRow {
 					w.logger.Error("Got class twice: ", row.Schema, row.Digest)

--- a/qan/perfschema/worker.go
+++ b/qan/perfschema/worker.go
@@ -354,7 +354,6 @@ ROW_LOOP:
 						// To make explains works
 						digestText = `SELECT "perf_schema_tables_are_full"`
 					}
-					fmt.Println(digestText)
 					if err != nil {
 						w.logger.Error(err)
 						continue

--- a/test/qan/perfschema/004/iter01.json
+++ b/test/qan/perfschema/004/iter01.json
@@ -1,0 +1,30 @@
+[
+	{
+		"Schema": "db1",
+		"Digest": "",
+		"CountStar": 1,
+		"SumTimerWait": 804610000,
+		"MinTimerWait": 804610000,
+		"AvgTimerWait": 804610000,
+		"MaxTimerWait": 804610000,
+		"SumLockTime": 167000000,
+		"SumErrors": 0,
+		"SumWarnings": 0,
+		"SumRowsAffected": 0,
+		"SumRowsSent": 10,
+		"SumRowsExamined": 10,
+		"SumCreatedTmpDiskTables": 0,
+		"SumCreatedTmpTables": 1,
+		"SumSelectFullJoin": 0,
+		"SumSelectFullRangeJoin": 0,
+		"SumSelectRange": 0,
+		"SumSelectRangeCheck": 0,
+		"SumSelectScan": 1,
+		"SumSortMergePasseS": 0,
+		"SumSortRange": 0,
+		"SumSortRows": 0,
+		"SumSortScan": 0,
+		"FirstSeen": "2015-01-01T12:00:00Z",
+		"LastSeen": "2015-01-01T12:00:30Z"
+	}
+]

--- a/test/qan/perfschema/004/iter02.json
+++ b/test/qan/perfschema/004/iter02.json
@@ -1,0 +1,30 @@
+[
+	{
+		"Schema": "db1",
+		"Digest": "",
+		"CountStar": 2,
+		"SumTimerWait": 874610000,
+		"MinTimerWait": 804610000,
+		"AvgTimerWait": 743220000,
+		"MaxTimerWait": 854610000,
+		"SumLockTime": 267000000,
+		"SumErrors": 0,
+		"SumWarnings": 0,
+		"SumRowsAffected": 0,
+		"SumRowsSent": 20,
+		"SumRowsExamined": 20,
+		"SumCreatedTmpDiskTables": 0,
+		"SumCreatedTmpTables": 2,
+		"SumSelectFullJoin": 0,
+		"SumSelectFullRangeJoin": 0,
+		"SumSelectRange": 0,
+		"SumSelectRangeCheck": 0,
+		"SumSelectScan": 2,
+		"SumSortMergePasseS": 0,
+		"SumSortRange": 0,
+		"SumSortRows": 0,
+		"SumSortScan": 0,
+		"FirstSeen": "2015-01-01T12:00:00Z",
+		"LastSeen": "2015-01-01T12:01:10Z"
+	}
+]

--- a/test/qan/perfschema/004/res01.json
+++ b/test/qan/perfschema/004/res01.json
@@ -1,0 +1,95 @@
+{
+    "Class": [
+        {
+            "Fingerprint": "select 1",
+            "Id": "C40318BFC3888AED",
+            "Metrics": {
+                "BoolMetrics": {
+                    "Full_join": {
+                        "True": 0
+                    },
+                    "Full_scan": {
+                        "True": 1
+                    },
+                    "Tmp_table": {
+                        "True": 1
+                    },
+                    "Tmp_table_on_disk": {
+                        "True": 0
+                    }
+                },
+                "NumberMetrics": {
+                    "Merge_passes": {
+                        "Sum": 0
+                    },
+                    "Rows_affected": {
+                        "Sum": 0
+                    },
+                    "Rows_examined": {
+                        "Sum": 10
+                    },
+                    "Rows_sent": {
+                        "Sum": 10
+                    }
+                },
+                "TimeMetrics": {
+                    "Lock_time": {
+                        "Sum": 0.000100
+                    },
+                    "Query_time": {
+                        "Avg": 0.000743,
+                        "Max": 0.000855,
+                        "Min": 0.000805,
+                        "Sum": 0.000070
+                    }
+                }
+            },
+            "TotalQueries": 1
+        }
+    ],
+    "Global": {
+        "Metrics": {
+            "BoolMetrics": {
+                "Full_join": {
+                    "True": 0
+                },
+                "Full_scan": {
+                    "True": 1
+                },
+                "Tmp_table": {
+                    "True": 1
+                },
+                "Tmp_table_on_disk": {
+                    "True": 0
+                }
+            },
+            "NumberMetrics": {
+                "Merge_passes": {
+                    "Sum": 0
+                },
+                "Rows_affected": {
+                    "Sum": 0
+                },
+                "Rows_examined": {
+                    "Sum": 10
+                },
+                "Rows_sent": {
+                    "Sum": 10
+                }
+            },
+            "TimeMetrics": {
+                "Lock_time": {
+                    "Sum": 0.000100
+                },
+                "Query_time": {
+                    "Avg": 0.000743,
+                    "Max": 0.000855,
+                    "Min": 0.000805,
+                    "Sum": 0.000070
+                }
+            }
+        },
+        "TotalQueries": 1,
+        "UniqueQueries": 1
+    }
+}


### PR DESCRIPTION
If events_statements_summary_by_digest is full, MySQL will start setting the digest to NULL and will only compute a summary under that null digest.
See http://dev.mysql.com/doc/refman/5.6/en/statement-summary-tables.html#idm140190647360848
In that case, we set the digest to the string NULL to support this  summary in PCT