### PR TITLE
PCT-1675: Agent should limit the size of its data spool

### DIFF
--- a/Authors
+++ b/Authors
@@ -3,3 +3,4 @@ Vadim Tkachenko
 Kamil Dziedzic
 Oleg Vakheta
 Carlos Salguero
+Miguel Paolino

--- a/Changelog
+++ b/Changelog
@@ -2,10 +2,11 @@ percona-agent Changelog
 
 v1.0.13
 
-  * Updated diskv package to avoid potential goroutine leaks
+  * PCT-1438: First and last seen query timestamps are not converted to UTC
   * PCT-1619: QAN for Performance Schema crashes on null digest
   * PCT-1669: Agent logs all warnings like "strconv.ParseFloat: parsing "ON": invalid syntax"
-  * PCT-1438: Fixes for last_seen & first_seen
+  * PCT-1675: Agent should limit the size of its data spool
+  * Update diskv package to avoid potential goroutine leaks
 
 v1.0.12 released 2015-04-08
 

--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -19,7 +19,7 @@
         },
         {
             "ImportPath": "github.com/percona/cloud-protocol/proto",
-            "Rev": "3a7a14cdd91c2bfe32a713bb58d103a10c2511fb"
+            "Rev": "d02794d8269a6d385a19bddea242e20468f3f985"
         },
         {
             "ImportPath": "github.com/percona/go-mysql/event",

--- a/data/config.go
+++ b/data/config.go
@@ -17,13 +17,21 @@
 
 package data
 
+import (
+	"github.com/percona/cloud-protocol/proto/v1"
+)
+
 const (
 	DEFAULT_DATA_ENCODING      = "gzip"
 	DEFAULT_DATA_SEND_INTERVAL = 63
+	DEFAULT_DATA_MAX_AGE       = 3600             // 1h
+	DEFAULT_DATA_MAX_SIZE      = 1024 * 1024 * 10 // 10 MiB
+	DEFAULT_DATA_MAX_FILES     = 100
 )
 
 type Config struct {
 	Encoding     string
 	SendInterval uint
-	Blackhole    bool
+	Blackhole    bool // don't send if true
+	Limits       proto.DataSpoolLimits
 }

--- a/data/spooler.go
+++ b/data/spooler.go
@@ -291,25 +291,23 @@ func (s *DiskvSpooler) run() {
 			n, removed := s.purge(time.Now().UTC(), s.limits)
 			if n == 0 {
 				s.logger.Info("Spool size is ok, no files purged")
-			} else {
-				if len(removed["purged"]) > 0 {
-					s.logger.Warn("Purged all data files")
-				} else {
-					for reason, files := range removed {
-						if len(files) == 0 {
-							continue
-						}
-						switch reason {
-						case "age":
-							s.logger.Warn(fmt.Sprintf("Removed %d old data files", len(files)))
-						case "size":
-							s.logger.Warn(fmt.Sprintf("Removed %d data files to reduce spool size", len(files)))
-						case "files":
-							s.logger.Warn(fmt.Sprintf("Removed %d data files to reduce number of files", len(files)))
-						default:
-							s.logger.Warn(fmt.Sprintf("Removed %d data files", len(files)))
-						}
-					}
+				continue
+			}
+			for reason, files := range removed {
+				if len(files) == 0 {
+					continue
+				}
+				switch reason {
+				case "age":
+					s.logger.Warn(fmt.Sprintf("Removed %d old data files", len(files)))
+				case "size":
+					s.logger.Warn(fmt.Sprintf("Removed %d data files to reduce spool size", len(files)))
+				case "files":
+					s.logger.Warn(fmt.Sprintf("Removed %d data files to reduce number of files", len(files)))
+				case "purged":
+					s.logger.Warn(fmt.Sprintf("Purged all %d data files", len(files)))
+				default:
+					s.logger.Warn(fmt.Sprintf("Removed %d data files", len(files)))
 				}
 			}
 		case <-s.sync.StopChan:

--- a/test/mock/spooler.go
+++ b/test/mock/spooler.go
@@ -18,6 +18,9 @@
 package mock
 
 import (
+	"time"
+
+	"github.com/percona/cloud-protocol/proto/v1"
 	"github.com/percona/percona-agent/data"
 )
 
@@ -90,4 +93,8 @@ func (s *Spooler) Reject(file string) error {
 func (s *Spooler) Reset() {
 	s.DataIn = []interface{}{}
 	s.RejectedFiles = []string{}
+}
+
+func (s *Spooler) Purge(now time.Time, limits proto.DataSpoolLimits) (int, map[string][]string) {
+	return 0, nil
 }


### PR DESCRIPTION
* Adds `proto.DataSpoolLimits` (https://github.com/percona/cloud-protocol/commit/d02794d8269a6d385a19bddea242e20468f3f985)
* Adds Purge cmd, takes optional `proto.DataSpoolLimits`
* Adds auto-purging every 15m
* Backwards-compatible; defaults to 1 hour, 10 MiB, or 100 files